### PR TITLE
wrong upload_path

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -308,6 +308,10 @@ class File implements \ArrayAccess, \Iterator, \Countable
 			{
 				$this->container['path'] = rtrim($this->config['path'], DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
 			}
+			// path is not exists and create_path is disable 
+			if ( !is_dir($this->container['path']) and (bool) !$this->config['create_path']){
+            	throw new \DomainException('Can\'t save the uploaded file. Destination path specified does not exist.');
+			}
 
 			// create the path if needed
 			if ( ! is_dir($this->container['path']) and (bool) $this->config['create_path'])


### PR DESCRIPTION
When i set create_path=false and path that is not exists. I still can upload files successfully. But files were saved to / dir. I think, it must throw a exception, that is right.
